### PR TITLE
Allow PHP 8 installations

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
-/tests export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .php_cs export-ignore
@@ -6,3 +5,4 @@
 .travis.yml export-ignore
 phpstan.neon.dist export-ignore
 phpunit.xml.dist export-ignore
+/tests export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-vendor/
-composer.lock
-phpunit.xml
 .phpunit.result.cache
 .php_cs.cache
+composer.lock
+phpunit.xml
+vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
 
 install:
   - travis_retry composer install --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "psr/container": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
### Proposed changes
 
Add `^8.0` in `php` requirement version range.

